### PR TITLE
update SDK - use of network utils 

### DIFF
--- a/extensions/walletProviders/evm/package.json
+++ b/extensions/walletProviders/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tatumio/evm-wallet-provider",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "EVM provider with local wallet operations",
   "author": "Tatum",
   "repository": "https://github.com/tatumio/ecosystem-addons/blob/master/extensions/walletProviders/evm/README.md",
@@ -45,7 +45,7 @@
     "ethers": "^6.7.1"
   },
   "devDependencies": {
-    "@tatumio/tatum": "^4.1.7",
+    "@tatumio/tatum": "^4.2.5",
     "typescript": "^5.2.2",
     "@types/elliptic": "^6.4.15",
     "@types/jest": "^29.5.5",

--- a/extensions/walletProviders/evm/src/consts.ts
+++ b/extensions/walletProviders/evm/src/consts.ts
@@ -30,5 +30,5 @@ export const DERIVATION_PATHS = new Map<Network, string>([
   [Network.PALM, EVM_DERIVATION_PATH_COMMON],
   [Network.POLYGON, "m/44'/966'/0'/0"],
   [Network.VECHAIN, "m/44'/818'/0'/0"],
-  [Network.XDC, "m/44'/550'/0'/0"],
+  [Network.XINFIN, "m/44'/550'/0'/0"],
 ])

--- a/extensions/walletProviders/evm/src/extension.ts
+++ b/extensions/walletProviders/evm/src/extension.ts
@@ -1,11 +1,5 @@
-import {
-  EvmRpc,
-  ITatumSdkContainer,
-  Network,
-  TatumConfig,
-  TatumSdkWalletProvider,
-  TatumUtils
-} from '@tatumio/tatum'
+import { EvmRpc, ITatumSdkContainer, Network, TatumConfig, TatumSdkWalletProvider } from '@tatumio/tatum'
+import { NetworkUtils } from '@tatumio/tatum/dist/src/util/network.utils'
 import { generateMnemonic as bip39GenerateMnemonic } from 'bip39'
 import ethWallet, { hdkey } from 'ethereumjs-wallet'
 import { ethers } from 'ethers'
@@ -127,7 +121,7 @@ export class EvmWalletProvider extends TatumSdkWalletProvider<EvmWallet, EvmTxPa
   public async signAndBroadcast(payload: EvmTxPayload): Promise<string> {
     const { privateKey, ...tx } = payload
 
-    const chainId = TatumUtils.getChainId(this.sdkConfig.network)
+    const chainId = NetworkUtils.getChainId(this.sdkConfig.network)
     const provider = new TatumProvider(chainId, this.evmRpc)
     const signer = new ethers.Wallet(privateKey, provider)
     const txRequest = {
@@ -165,8 +159,8 @@ export class EvmWalletProvider extends TatumSdkWalletProvider<EvmWallet, EvmTxPa
     Network.BINANCE_SMART_CHAIN_TESTNET,
     Network.VECHAIN,
     Network.VECHAIN_TESTNET,
-    Network.XDC,
-    Network.XDC_TESTNET,
+    Network.XINFIN,
+    Network.XINFIN_TESTNET,
     Network.PALM,
     Network.PALM_TESTNET,
     Network.CRONOS,

--- a/extensions/walletProviders/evm/yarn.lock
+++ b/extensions/walletProviders/evm/yarn.lock
@@ -673,12 +673,13 @@
   dependencies:
     "@sinonjs/commons" "^3.0.0"
 
-"@tatumio/tatum@^4.1.7":
-  version "4.1.7"
-  resolved "https://registry.yarnpkg.com/@tatumio/tatum/-/tatum-4.1.7.tgz#88acc9687e9b3df1855c4f6f3f67630f6f9dcec5"
-  integrity sha512-D7EmtWugflaDa9YAe9Y1183Oa4YRRGuIcizpOWdgwoZeLQmtVhmasHGCZbxGgxTUTKa6EJNcZ7AH8ZbbdAm1Aw==
+"@tatumio/tatum@^4.2.5":
+  version "4.2.5"
+  resolved "https://registry.yarnpkg.com/@tatumio/tatum/-/tatum-4.2.5.tgz#c15d33dd7a74722083ad66d5a3221b9af3106d86"
+  integrity sha512-QkOD6+q3f0hXvvN/S6s4DYZQwnooHL5NYGA/etGdoBXQl+/J+oNbG7plySzvPzhZfQn3P5Ps6L3wZyrJSwyqzw==
   dependencies:
     bignumber.js "^9.1.1"
+    chalk "^4.1.2"
     reflect-metadata "^0.1.13"
     typedi "^0.10.0"
 
@@ -1229,7 +1230,7 @@ chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0:
+chalk@^4.0.0, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==


### PR DESCRIPTION
I encountered an error while utilizing the SDK in conjunction with the EVM provider. Upon investigation, it became apparent that the removal of TatumUtils in the latest SDK release was the root cause of the issue.

In this pull request, I aim to address and rectify this issue. I recognize that there may be alternative or more efficient approaches to implementing this fix, and I am open to feedback and suggestions from the team to enhance the solution.